### PR TITLE
Add selected text for block snippets

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -23,7 +23,7 @@
     "list": {
         "prefix": "list",
         "body": [
-            ".{$0};"
+            ".{$TM_SELECTED_TEXT$0};"
         ],
         "description": "anonymous list"
     },
@@ -31,7 +31,7 @@
         "prefix": "fn",
         "body": [
             "fn ${1:name}($0) {",
-            "    ",
+            "    $TM_SELECTED_TEXT",
             "}"
         ],
         "description": "fn decl"
@@ -40,7 +40,7 @@
         "prefix": "fn_gen",
         "body": [
             "fn ${1:name}(comptime T: type, $0) type {",
-            "    ",
+            "    $TM_SELECTED_TEXT",
             "}"
         ],
         "description": "generic fn decl"
@@ -49,7 +49,7 @@
         "prefix": "pub_fn",
         "body": [
             "pub fn ${1:name}($0) {",
-            "    ",
+            "    $TM_SELECTED_TEXT",
             "}"
         ],
         "description": "pub fn decl"
@@ -65,7 +65,7 @@
         "prefix": "fn_exp",
         "body": [
             "export fn ${1:name}($0) {",
-            "    ",
+            "    $TM_SELECTED_TEXT",
             "}"
         ],
         "description": "export fn"
@@ -74,7 +74,7 @@
         "prefix": "inl_fn",
         "body": [
             "inline fn ${1:name}($0) {",
-            "    ",
+            "    $TM_SELECTED_TEXT",
             "}"
         ],
         "description": "inline fn"
@@ -83,7 +83,7 @@
         "prefix": "naked_fn",
         "body": [
             "nakedcc fn _${1:name}($0) {",
-            "    ",
+            "    $TM_SELECTED_TEXT",
             "}"
         ],
         "description": "nakedcc fn"
@@ -92,7 +92,7 @@
         "prefix": "block",
         "body": [
             "${1:label}: {",
-            "    $0",
+            "    $TM_SELECTED_TEXT$0",
             "    break :${1:label} return_value",
             "};"
         ],
@@ -102,7 +102,7 @@
         "prefix": "stru_val",
         "body": [
             "struct {",
-            "    $0",
+            "    $TM_SELECTED_TEXT$0",
             "};"
         ],
         "description": "struct val"
@@ -111,7 +111,7 @@
         "prefix": "stru_decl",
         "body": [
             "const ${1:StructName} = struct {",
-            "    $0",
+            "    $TM_SELECTED_TEXT$0",
             "};"
         ],
         "description": "struct decl"
@@ -120,7 +120,7 @@
         "prefix": "enum",
         "body": [
             "const ${1:EnumName} = enum(${2:type}) {",
-            "    $0",
+            "    $TM_SELECTED_TEXT$0",
             "};"
         ],
         "description": "enum decl"
@@ -129,7 +129,7 @@
         "prefix": "union",
         "body": [
             "const ${1:UnionName} = union(${2:enum}) {",
-            "    $0",
+            "    $TM_SELECTED_TEXT$0",
             "};"
         ],
         "description": "tagged union decl"
@@ -138,7 +138,7 @@
         "prefix": "for_v",
         "body": [
             "for ($0) |${1:v}| {",
-            "    ",
+            "    $TM_SELECTED_TEXT",
             "}"
         ],
         "description": "for value loop"
@@ -147,7 +147,7 @@
         "prefix": "for_v_i",
         "body": [
             "for ($0) |${1:v},${2:i}| {",
-            "    ",
+            "    $TM_SELECTED_TEXT",
             "}"
         ],
         "description": "for value,index loop"
@@ -156,7 +156,7 @@
         "prefix": "inl_for",
         "body": [
             "inline for ($0) |${1:v}| {",
-            "    ",
+            "    $TM_SELECTED_TEXT",
             "}"
         ],
         "description": "inline for loop"
@@ -166,7 +166,7 @@
         "body": [
             "${1:label}: for ($0) |_| {",
             "    for (iter) |_| {",
-            "        ",
+            "        $TM_SELECTED_TEXT",
             "        break :${1:label};",
             "    }",
             "}"
@@ -177,7 +177,7 @@
         "prefix": "for_else",
         "body": [
             "for ($0) |${1:v}| {",
-            "    ",
+            "    $TM_SELECTED_TEXT",
             "    break true;",
             "} else false;"
         ],
@@ -187,7 +187,7 @@
         "prefix": "while",
         "body": [
             "while ($0) : () {",
-            "    ",
+            "    $TM_SELECTED_TEXT",
             "}"
         ],
         "description": "while loop"
@@ -196,7 +196,7 @@
         "prefix": "while_else",
         "body": [
             "while ($0) : () {",
-            "    ",
+            "    $TM_SELECTED_TEXT",
             "    break true;",
             "} else false;"
         ],
@@ -206,7 +206,7 @@
         "prefix": "while?",
         "body": [
             "while ($0) |${1:v}| {",
-            "    ",
+            "    $TM_SELECTED_TEXT",
             "} else |err| {",
             "    ",
             "}"
@@ -228,7 +228,7 @@
         "prefix": "inl_while",
         "body": [
             "inline while ($0) () {",
-            "    ",
+            "    $TM_SELECTED_TEXT",
             "}"
         ],
         "description": "inline while loop"
@@ -237,7 +237,7 @@
         "prefix": "if",
         "body": [
             "if ($0) {",
-            "    ",
+            "    $TM_SELECTED_TEXT",
             "}"
         ],
         "description": "if expr"
@@ -246,7 +246,7 @@
         "prefix": "if_else",
         "body": [
             "if ($0) {",
-            "    ",
+            "    $TM_SELECTED_TEXT",
             "} else {",
             "    ",
             "}"
@@ -257,7 +257,7 @@
         "prefix": "if?",
         "body": [
             "if ($0) |v| {",
-            "    ",
+            "    $TM_SELECTED_TEXT",
             "}"
         ],
         "description": "if optional"
@@ -266,7 +266,7 @@
         "prefix": "if_else?",
         "body": [
             "if ($0) |v| {",
-            "    ",
+            "    $TM_SELECTED_TEXT",
             "} else |err| switch(err) {",
             "     => ,",
             "    else => ,",
@@ -288,7 +288,7 @@
         "prefix": "test",
         "body": [
             "test ${1:name} {",
-            "    $0",
+            "    $TM_SELECTED_TEXT$0",
             "    assert(true)",
             "}"
         ],
@@ -305,7 +305,7 @@
         "prefix": "def",
         "body": [
             "defer {",
-            "    $0",
+            "    $TM_SELECTED_TEXT$0",
             "}"
         ],
         "description": "defer block"
@@ -314,7 +314,7 @@
         "prefix": "errd",
         "body": [
             "errdefer {",
-            "    $0",
+            "    $TM_SELECTED_TEXT$0",
             "}"
         ],
         "description": "errdefer block"
@@ -323,7 +323,7 @@
         "prefix": "error",
         "body": [
             "error {",
-            "    $0",
+            "    $TM_SELECTED_TEXT$0",
             "};"
         ],
         "description": "error decl"
@@ -332,7 +332,7 @@
         "prefix": "catch",
         "body": [
             "catch |$0| {",
-            "    ",
+            "    $TM_SELECTED_TEXT",
             "};"
         ],
         "description": "catch error block"
@@ -341,7 +341,7 @@
         "prefix": "comp",
         "body": [
             "comptime {",
-            "    $0",
+            "    $TM_SELECTED_TEXT$0",
             "}"
         ],
         "description": "comptime block"
@@ -350,7 +350,7 @@
         "prefix": "asm",
         "body": [
             "asm $0 (",
-            "    ",
+            "    $TM_SELECTED_TEXT",
             ");"
         ],
         "description": "asm block"
@@ -359,7 +359,7 @@
         "prefix": "suspend",
         "body": [
             "suspend {",
-            "    $0",
+            "    $TM_SELECTED_TEXT$0",
             "}"
         ],
         "description": "suspend block"


### PR DESCRIPTION
Use $TM_SELECTED_TEXT to block snippets:

Usage in vs code: open command palette, Insert snippet.

When choosing one of the block snippets the selected code won't be removed.
It would be wrapped up by the block.